### PR TITLE
xrbuddy: fix swapchain format selection

### DIFF
--- a/src/core/xrbuddy.cpp
+++ b/src/core/xrbuddy.cpp
@@ -885,7 +885,6 @@ static bool CreateSwapchains(XrInstance instance, XrSession session,
                 foundFormatIndex = i;
                 break;
             }
-            i++;
         }
         if (foundFormatIndex != swapchainFormatCount)
         {


### PR DESCRIPTION
Increment was performed twice, so we could miss the desired format!