### PR TITLE
openxr: make renderer compatible with X11 Linux

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -250,9 +250,9 @@ VR Controls\n\
 \n");
 }
 
-App::App(const MainContext& mainContextIn)
+App::App(MainContext& mainContextIn):
+    mainContext(mainContextIn)
 {
-    mainContext = mainContextIn;
     cameraIndex = 0;
     virtualLeftStick = glm::vec2(0.0f, 0.0f);
     virtualRightStick = glm::vec2(0.0f, 0.0f);

--- a/src/app.h
+++ b/src/app.h
@@ -31,7 +31,7 @@ union SDL_Event;
 class App
 {
 public:
-    App(const MainContext& mainContextIn);
+    App(MainContext& mainContextIn);
 
     enum ParseResult
     {
@@ -66,7 +66,7 @@ protected:
         bool drawFps = true;
     };
 
-    MainContext mainContext;
+    MainContext& mainContext;
     Options opt;
     std::string plyFilename;
     std::shared_ptr<DebugRenderer> debugRenderer;

--- a/src/core/xrbuddy.cpp
+++ b/src/core/xrbuddy.cpp
@@ -409,21 +409,12 @@ static bool CreateSession(XrInstance instance, XrSystemId systemId, XrSession& s
     glBinding.hDC = wglGetCurrentDC();
     glBinding.hGLRC = wglGetCurrentContext();
 #else
-
-    // AJT: TODO: need to collect all the x11 stuff from the app and SDL.
-
     XrGraphicsBindingOpenGLXlibKHR glBinding = {};
     glBinding.type = XR_TYPE_GRAPHICS_BINDING_OPENGL_XLIB_KHR;
     glBinding.next = NULL;
-    /*
-    glBinding.xDisplay = xDisplay;
-    glBinding.visualid = ??;
-    glBinding.glxFBConfig = ??;
-    glBinding.glxDrawable = ??;
-    glBinding.glxContext = ??;
-    */
-    Log::E("OpenXR support not implemented!\n");
-    return false;
+    glBinding.xDisplay = mainContext.xdisplay;
+    glBinding.glxDrawable = mainContext.glxDrawable;
+    glBinding.glxContext = mainContext.glxContext;
 #endif
 
 #elif defined (XR_USE_GRAPHICS_API_OPENGL_ES)
@@ -982,9 +973,9 @@ static GLuint CreateDepthTexture(GLuint colorTexture, GLint width, GLint height)
     return depthTexture;
 }
 
-XrBuddy::XrBuddy(const MainContext& mainContextIn, const glm::vec2& nearFarIn)
+XrBuddy::XrBuddy(MainContext& mainContextIn, const glm::vec2& nearFarIn):
+    mainContext(mainContextIn)
 {
-    mainContext = mainContextIn;
     nearFar = nearFarIn;
 
 #ifdef XR_USE_GRAPHICS_API_OPENGL

--- a/src/core/xrbuddy.h
+++ b/src/core/xrbuddy.h
@@ -51,7 +51,7 @@
 class XrBuddy
 {
 public:
-    XrBuddy(const MainContext& mainContextIn, const glm::vec2& nearFarIn);
+    XrBuddy(MainContext& mainContextIn, const glm::vec2& nearFarIn);
 
     bool Init();
     bool PollEvents();
@@ -124,7 +124,7 @@ protected:
                     uint32_t colorTexture, uint32_t depthTexture, int32_t viewNum);
 
     bool constructorSucceded = false;
-    MainContext mainContext;
+    MainContext& mainContext;
     XrSessionState state = XR_SESSION_STATE_UNKNOWN;
     std::vector<XrExtensionProperties> extensionProps;
     std::vector<XrApiLayerProperties> layerProps;

--- a/src/sdl_main.cpp
+++ b/src/sdl_main.cpp
@@ -10,6 +10,7 @@
 #include <glm/glm.hpp>
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_opengl.h>
+#include <SDL2/SDL_syswm.h>
 #include <stdint.h>
 #include <thread>
 
@@ -88,6 +89,21 @@ int main(int argc, char *argv[])
     ctx.gl_context = SDL_GL_CreateContext(ctx.window);
 
     SDL_GL_MakeCurrent(ctx.window, ctx.gl_context);
+
+    // Initialize context from the SDL window
+    SDL_SysWMinfo info;
+    SDL_VERSION(&info.version)
+    auto ret = SDL_GetWindowWMInfo(ctx.window, &info);
+    if (ret != SDL_TRUE)
+    {
+        Log::W("Failed to retrieve SDL window info: %s\n", SDL_GetError());
+    }
+    else
+    {
+        mainContext.xdisplay = info.info.x11.display;
+        mainContext.glxDrawable = (GLXWindow)info.info.x11.window;
+        mainContext.glxContext = (GLXContext)ctx.gl_context;
+    }
 
     GLenum err = glewInit();
     if (GLEW_OK != err)


### PR DESCRIPTION
Implement the retrieval of X window details required by the XrGraphicsBindingOpenGLXlibKHR struct for initializing the OpenXR graphics binding on X11-based Linux.

Splatapult now works on Linux with SteamVR/OpenXR runtime.

To test:

1. Install SteamVR
2. Make SteamVR the OpenXR default runtime ( Settings > OpenXR > SET STEAMVR AS OPENXR RUNTIME)
3. Restart SteamVR
4. Run `splatapult`