### PR TITLE
Update ply.h to include cstdint for uint8_t support

### DIFF
--- a/src/ply.h
+++ b/src/ply.h
@@ -8,6 +8,7 @@
 #include <cassert>
 #include <functional>
 #include <string>
+#include <cstdint>
 #include <unordered_map>
 #include <vector>
 

--- a/src/pointcloud.h
+++ b/src/pointcloud.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 class PointCloud
 {


### PR DESCRIPTION
Adding include for uint8_t definition on linux systems.

Application fails to make, and types fail to define due to uint8_t definition being defined in cstdint.